### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Note that you will also need to install the requisite dependencies for mysqlclie
 
 ```bash
 sudo apt-get update
-sudo apt-get install package-cfg libmysqlclient-dev
+sudo apt-get install libmariadb-dev
 ```
 
 ## Configuration
@@ -173,6 +173,9 @@ ERROR 1049 (42000): VT05003: unknown database 'information_schema' in vschema
 Note that PlanetScale has a singer tap that they support. It's located here https://github.com/planetscale/singer-tap/
 It's written in Go, and it also supports Log Based replication.
 This is a great alternative to this tap if you're using PlanetScale.
+
+### Troubleshooting
+If the MySQL user does not have permissions to read from the `performance_schema.global_variables` table to check if the database is a PlanetScale MySQL instance, execution of the tap might fail with a `SELECT command denied to user` exception. To solve this issue, set `is_vitess = False`.
 
 ## Developer Resources
 


### PR DESCRIPTION
Hello, 
I just tried to setup the tap on a Debian Bookworm instance and the installation failed with the following error:

```
2.357 Reading package lists...
2.755 Building dependency tree...
3.014 Reading state information...
3.016 Package libmysqlclient-dev is not available, but is referred to by another package.
3.016 This may mean that the package is missing, has been obsoleted, or
3.016 is only available from another source
3.016 However the following packages replace it:
3.016   libmariadb-dev-compat libmariadb-dev
3.016 
3.018 E: Unable to locate package package-cfg
3.018 E: Package 'libmysqlclient-dev' has no installation candidate
```

I solved the issue by using ` libmariadb-dev`.

I also was working with a non priviliged MySql user and the check whether the database is a PlanetScale database failed with the following error:  
```
"SELECT command denied to user 'xxxxxxxx'@'xxxxxxxx.dip0.t-ipconnect.de' for table `performance_schema`.`global_variables`")
[SQL: select variable_value from performance_schema.global_variables where variable_name='version_comment' and variable_value like 'PlanetScale%%']
```

It took me some time to find the source of this error so I wanted to share.
Cheers!
