### PR TITLE
Add skip ordering

### DIFF
--- a/tap_mysql/client.py
+++ b/tap_mysql/client.py
@@ -436,9 +436,11 @@ class MySQLStream(SQLStream):
             column_names=selected_column_names,
         )
         query = table.select()
+        skip_ordering = self.config.get("skip_ordering", False)
         if self.replication_key:
             replication_key_col = table.columns[self.replication_key]
-            query = query.order_by(replication_key_col)
+            if not skip_ordering:
+                query = query.order_by(replication_key_col)
 
             start_val = self.get_starting_replication_key_value(context)
             if start_val:

--- a/tap_mysql/tap.py
+++ b/tap_mysql/tap.py
@@ -117,6 +117,17 @@ class TapMySQL(SQLTap):
             ),
         ),
         th.Property(
+            "skip_ordering",
+            th.BooleanType,
+            default=False,
+            description=(
+                "If true, disables ORDER BY when fetching data. "
+                "It can be useful when you have huge json columns inside your database and "
+                "ordering them throws memory related issues. "
+                "This may negatively affect incremental syncs and should be used with caution."
+            ),
+        ),
+        th.Property(
             "filter_schemas",
             th.ArrayType(th.StringType),
             description=(


### PR DESCRIPTION
Add `skip_ordering` flag.

It can be useful when you have huge json columns inside your database and ordering them throws memory related issues.
This may negatively affect incremental syncs and should be used with caution.